### PR TITLE
feat(ui): 添加单双打模式和简单伤害计算

### DIFF
--- a/pokepilot/ui/index.html
+++ b/pokepilot/ui/index.html
@@ -59,6 +59,7 @@
             </div>
             <div class="menu-item" onclick="captureScreen('opp_team')">截取对方队伍</div>
             <div class="menu-item" onclick="generateOpponentTeam()">生成对方队伍</div>
+            <div class="menu-item" id="battle-mode-toggle" onclick="toggleBattleMode()">双打</div>
 
             <div class="menu-status" id="status">等待</div>
         </div>
@@ -132,6 +133,14 @@
                 <button onclick="buildTeamFromDraft()">生成队伍</button>
             </div>
         </div>
+    </div>
+
+    <div id="move-damage-overlay" class="move-damage-overlay">
+        <div class="move-damage-header">
+            <span id="move-damage-title">技能伤害范围</span>
+            <button onclick="closeMoveDamageOverlay()">×</button>
+        </div>
+        <div id="move-damage-content" class="move-damage-content"></div>
     </div>
 
     <script src="script.js"></script>

--- a/pokepilot/ui/style.css
+++ b/pokepilot/ui/style.css
@@ -558,6 +558,10 @@ video {
     box-shadow: 0 0 4px rgba(255, 255, 255, 0.3);
 }
 
+.move-chip.clickable {
+    cursor: pointer;
+}
+
 .move-stats {
     font-size: 9px;
     opacity: 0.9;
@@ -1078,5 +1082,85 @@ video {
 .draft-editor-footer button:last-child:hover {
     background: #0a5a5d;
     border-color: #0a5a5d;
+}
+
+/* ==================== 技能伤害范围悬浮窗 ==================== */
+.move-damage-overlay {
+    position: fixed;
+    right: 16px;
+    top: 48px;
+    width: 360px;
+    max-height: 70vh;
+    border: 1px solid #3e3e42;
+    background: #1e1e1e;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    z-index: 1100;
+    display: none;
+    flex-direction: column;
+}
+
+.move-damage-overlay.open {
+    display: flex;
+}
+
+.move-damage-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    border-bottom: 1px solid #3e3e42;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: move;
+    user-select: none;
+}
+
+.move-damage-header button {
+    border: 1px solid #555;
+    background: #2d2d2d;
+    color: #ddd;
+    border-radius: 4px;
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+}
+
+.move-damage-content {
+    overflow-y: auto;
+    padding: 8px;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.move-damage-row {
+    background: #252526;
+    border: 1px solid #333;
+    border-radius: 6px;
+    padding: 8px;
+    margin-bottom: 8px;
+}
+
+.move-damage-row-name {
+    font-weight: 600;
+    color: #e0e0e0;
+}
+
+.move-damage-name-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.move-damage-type-icons {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+}
+
+.move-damage-row-range {
+    margin-top: 4px;
+    color: #4ec9b0;
 }
 

--- a/pokepilot/ui/team.js
+++ b/pokepilot/ui/team.js
@@ -39,6 +39,7 @@ let speedFieldState = {
 };
 let moveDamageDragState = null;
 let battleMode = 'double';
+let lastDamageQuery = null;
 
 
 function getEffectiveSpeed(speed, hasTailwind) {
@@ -510,6 +511,7 @@ async function showMoveDamageRange(side, pokemonIndex, moveIndex) {
     }
 
     const move = attacker.moves[moveIndex];
+    lastDamageQuery = { side, pokemonIndex, moveIndex };
     title.textContent = `${attacker.name_zh || attacker.name} - ${move.name_zh || move.name}`;
     content.textContent = '计算中...';
     overlay.classList.add('open');
@@ -545,6 +547,9 @@ async function showMoveDamageRange(side, pokemonIndex, moveIndex) {
         }
         if (data.is_multi_hit) {
             title.textContent += '（多段技能，当前为单段伤害）';
+        }
+        if (data.is_guaranteed_crit) {
+            title.textContent += '（必定要害修正）';
         }
         renderMoveDamageRows(data.rows || []);
     } catch (err) {
@@ -1014,6 +1019,14 @@ function switchEvoform(side, index, evoIndex) {
     }
 
     renderTeam(team, side);
+    const overlay = document.getElementById('move-damage-overlay');
+    if (overlay && overlay.classList.contains('open') && lastDamageQuery) {
+        showMoveDamageRange(
+            lastDamageQuery.side,
+            lastDamageQuery.pokemonIndex,
+            lastDamageQuery.moveIndex
+        );
+    }
 }
 
 async function generateOpponentTeam() {

--- a/pokepilot/ui/team.js
+++ b/pokepilot/ui/team.js
@@ -39,7 +39,6 @@ let speedFieldState = {
 };
 let moveDamageDragState = null;
 let battleMode = 'double';
-let lastDamageQuery = null;
 
 
 function getEffectiveSpeed(speed, hasTailwind) {
@@ -511,7 +510,6 @@ async function showMoveDamageRange(side, pokemonIndex, moveIndex) {
     }
 
     const move = attacker.moves[moveIndex];
-    lastDamageQuery = { side, pokemonIndex, moveIndex };
     title.textContent = `${attacker.name_zh || attacker.name} - ${move.name_zh || move.name}`;
     content.textContent = '计算中...';
     overlay.classList.add('open');
@@ -547,9 +545,6 @@ async function showMoveDamageRange(side, pokemonIndex, moveIndex) {
         }
         if (data.is_multi_hit) {
             title.textContent += '（多段技能，当前为单段伤害）';
-        }
-        if (data.is_guaranteed_crit) {
-            title.textContent += '（必定要害修正）';
         }
         renderMoveDamageRows(data.rows || []);
     } catch (err) {
@@ -1019,14 +1014,6 @@ function switchEvoform(side, index, evoIndex) {
     }
 
     renderTeam(team, side);
-    const overlay = document.getElementById('move-damage-overlay');
-    if (overlay && overlay.classList.contains('open') && lastDamageQuery) {
-        showMoveDamageRange(
-            lastDamageQuery.side,
-            lastDamageQuery.pokemonIndex,
-            lastDamageQuery.moveIndex
-        );
-    }
 }
 
 async function generateOpponentTeam() {

--- a/pokepilot/ui/team.js
+++ b/pokepilot/ui/team.js
@@ -37,6 +37,8 @@ let speedFieldState = {
     my_tailwind: false,
     opp_tailwind: false
 };
+let moveDamageDragState = null;
+let battleMode = 'double';
 
 
 function getEffectiveSpeed(speed, hasTailwind) {
@@ -233,13 +235,18 @@ function renderCard(pokemon, side, index) {
     }
 
     // 招式（用属性颜色作为背景，显示威力/准确度）
-    const moves = pokemon.moves.map(m => {
+    const moves = pokemon.moves.map((m, moveIdx) => {
         const powerAccuracy = m.power !== null ? `${m.power}/${m.accuracy ?? '-'}` : '-/-';
+        const priorityText = Number(m.priority || 0) !== 0 ? ` P${Number(m.priority) >= 0 ? '+' : ''}${m.priority}` : '';
         const desc = m.short_effect_zh || m.short_effect || '';
         const pctStr = m.pct ? `使用率: ${Math.round(m.pct * 100)}%` : '';
         const moveTitle = [desc, pctStr].filter(Boolean).join('\n');
         const moveName = m.name_zh || m.name || '';
-        return `<div class="move-chip type-${m.type.toLowerCase()}" title="${moveTitle.replace(/"/g, '&quot;')}">${moveName}<span class="move-stats">${powerAccuracy}</span></div>`;
+        const clickableClass = (side === 'my-team' || side === 'opp-team') ? ' clickable' : '';
+        const clickAttr = (side === 'my-team' || side === 'opp-team')
+            ? ` onclick="showMoveDamageRange('${side}', ${index}, ${moveIdx})"`
+            : '';
+        return `<div class="move-chip type-${m.type.toLowerCase()}${clickableClass}" title="${moveTitle.replace(/"/g, '&quot;')}"${clickAttr}>${moveName}<span class="move-stats">${powerAccuracy}${priorityText}</span></div>`;
     }).join('');
 
     // Stats barplot 显示
@@ -384,8 +391,171 @@ function renderTeam(team, side) {
     renderSpeedAxis();
 }
 
+
+function closeMoveDamageOverlay() {
+    const overlay = document.getElementById('move-damage-overlay');
+    if (!overlay) return;
+    overlay.classList.remove('open');
+}
+
+
+function updateBattleModeToggleLabel() {
+    const toggle = document.getElementById('battle-mode-toggle');
+    if (!toggle) return;
+    toggle.textContent = battleMode === 'double' ? '双打' : '单打';
+}
+
+
+function toggleBattleMode() {
+    battleMode = battleMode === 'double' ? 'single' : 'double';
+    updateBattleModeToggleLabel();
+}
+
+
+function onMoveDamageOverlayDragMove(event) {
+    if (!moveDamageDragState) return;
+    const overlay = moveDamageDragState.overlay;
+    const nextLeft = event.clientX - moveDamageDragState.offsetX;
+    const nextTop = event.clientY - moveDamageDragState.offsetY;
+    overlay.style.left = `${Math.max(0, nextLeft)}px`;
+    overlay.style.top = `${Math.max(0, nextTop)}px`;
+    overlay.style.right = 'auto';
+}
+
+
+function stopMoveDamageOverlayDrag() {
+    moveDamageDragState = null;
+    document.removeEventListener('mousemove', onMoveDamageOverlayDragMove);
+    document.removeEventListener('mouseup', stopMoveDamageOverlayDrag);
+}
+
+
+function startMoveDamageOverlayDrag(event) {
+    const overlay = document.getElementById('move-damage-overlay');
+    if (!overlay) return;
+    if (event.target.closest('button')) return;
+
+    const rect = overlay.getBoundingClientRect();
+    moveDamageDragState = {
+        overlay: overlay,
+        offsetX: event.clientX - rect.left,
+        offsetY: event.clientY - rect.top
+    };
+    document.addEventListener('mousemove', onMoveDamageOverlayDragMove);
+    document.addEventListener('mouseup', stopMoveDamageOverlayDrag);
+}
+
+
+function initMoveDamageOverlayDrag() {
+    const header = document.querySelector('#move-damage-overlay .move-damage-header');
+    if (!header || header.dataset.dragBound === '1') return;
+    header.dataset.dragBound = '1';
+    header.addEventListener('mousedown', startMoveDamageOverlayDrag);
+}
+
+
+function renderMoveDamageRows(rows) {
+    const content = document.getElementById('move-damage-content');
+    if (!content) return;
+    if (!rows || !rows.length) {
+        content.textContent = '没有可展示的目标。';
+        return;
+    }
+
+    content.innerHTML = rows.map((row) => {
+        const name = row.opp_name_zh || row.opp_name || '-';
+        const types = row.opp_types || [];
+        const range = row.range || {};
+        const dmgText = `${range.damage_min} - ${range.damage_max}`;
+        const hpText = `${range.hp_pct_min}% - ${range.hp_pct_max}%`;
+        const typeMult = Number(range.type_multiplier || 1).toFixed(2);
+        const hpRangeText = `${row.opp_hp_min || 0} - ${row.opp_hp_max || 0}`;
+        const typeIcons = types.map((typeName) => {
+            const typeId = TYPE_ID_MAP[typeName] || 1;
+            return `<div class="type-icon-small" style="background-image: url('/sprites/sprites/types/generation-ix/scarlet-violet/small/${typeId}.png')" title="${typeName}"></div>`;
+        }).join('');
+        return `
+            <div class="move-damage-row">
+                <div class="move-damage-name-row">
+                    <div class="move-damage-row-name">${name}</div>
+                    <div class="move-damage-type-icons">${typeIcons}</div>
+                </div>
+                <div class="move-damage-row-range">极限HP: ${hpRangeText}</div>
+                <div class="move-damage-row-range">伤害: ${dmgText}</div>
+                <div class="move-damage-row-range">生命值: ${hpText} (x${typeMult})</div>
+            </div>
+        `;
+    }).join('');
+}
+
+
+async function showMoveDamageRange(side, pokemonIndex, moveIndex) {
+    const myTeam = currentTeams['my-team'] || [];
+    const oppTeam = currentTeams['opp-team'] || [];
+    const isMySide = side === 'my-team';
+    const attackerTeam = isMySide ? myTeam : oppTeam;
+    const targetTeam = isMySide ? oppTeam : myTeam;
+    const attacker = attackerTeam[pokemonIndex];
+    const overlay = document.getElementById('move-damage-overlay');
+    const title = document.getElementById('move-damage-title');
+    const content = document.getElementById('move-damage-content');
+
+    if (!overlay || !title || !content) return;
+    if (!attacker || !attacker.moves || !attacker.moves[moveIndex]) return;
+    if (!targetTeam.length) {
+        title.textContent = '技能伤害范围';
+        content.textContent = isMySide ? '请先生成对方队伍。' : '请先生成我方队伍。';
+        overlay.classList.add('open');
+        return;
+    }
+
+    const move = attacker.moves[moveIndex];
+    title.textContent = `${attacker.name_zh || attacker.name} - ${move.name_zh || move.name}`;
+    content.textContent = '计算中...';
+    overlay.classList.add('open');
+
+    try {
+        const response = await fetch('/api/damage/range', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                attacker: attacker,
+                move_index: moveIndex,
+                opp_team: targetTeam,
+                battle_mode: battleMode
+            })
+        });
+        const contentType = response.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+            const text = await response.text();
+            content.textContent = `接口返回非JSON（HTTP ${response.status}）：${text.slice(0, 120)}`;
+            return;
+        }
+        const data = await response.json();
+        if (!data.success) {
+            content.textContent = `计算失败：${data.error || 'unknown'}`;
+            return;
+        }
+        if (Number(data.move_priority || 0) !== 0) {
+            const p = Number(data.move_priority);
+            title.textContent += `（先制度 ${p >= 0 ? '+' : ''}${p}）`;
+        }
+        if (data.battle_mode === 'double' && data.is_spread_move) {
+            title.textContent += '（双打范围修正）';
+        }
+        if (data.is_multi_hit) {
+            title.textContent += '（多段技能，当前为单段伤害）';
+        }
+        renderMoveDamageRows(data.rows || []);
+    } catch (err) {
+        content.textContent = `计算错误：${err.message}`;
+    }
+}
+
 window.addEventListener('load', () => {
     loadTeamMenus();
+    initMoveDamageOverlayDrag();
+    updateBattleModeToggleLabel();
 });
 
 // Team management

--- a/pokepilot/ui/ui_server.py
+++ b/pokepilot/ui/ui_server.py
@@ -99,10 +99,14 @@ def _compute_damage_range(attacker, defender, move):
 
     stab = 1.5 if move_type in attacker.get("types", []) else 1.0
     # 最低伤害：最低 roll + 对方最大防御
-    damage_min = _compute_damage_with_roll(power, atk_stat, def_max, stab, type_multiplier, 85)
+    is_guaranteed_crit = _is_guaranteed_crit_move(move)
+    crit_modifier = 1.5 if is_guaranteed_crit else 1.0
+    damage_min = _compute_damage_with_roll(
+        power, atk_stat, def_max, stab * crit_modifier, type_multiplier, 85
+    )
     # 最高伤害：最高 roll + 对方最小防御
     damage_max = _compute_damage_with_roll(
-        power, atk_stat, max(def_min, 1), stab, type_multiplier, 100
+        power, atk_stat, max(def_min, 1), stab * crit_modifier, type_multiplier, 100
     )
     hp_pct_min = round(damage_min * 100 / hp_max, 2)
     hp_pct_max = round(damage_max * 100 / hp_min, 2)
@@ -113,6 +117,7 @@ def _compute_damage_range(attacker, defender, move):
         "hp_pct_min": hp_pct_min,
         "hp_pct_max": hp_pct_max,
         "type_multiplier": type_multiplier,
+        "is_guaranteed_crit": is_guaranteed_crit,
     }
 
 
@@ -189,6 +194,27 @@ def _is_multi_hit_move(move):
     if any(token in short_effect for token in multi_hit_tokens):
         return True
     if "连续" in short_effect_zh and "攻击" in short_effect_zh:
+        return True
+    return False
+
+
+def _is_guaranteed_crit_move(move):
+    """识别必定击中要害技能。"""
+    move_name = (move.get("name") or "").lower().strip().replace(" ", "-").replace("_", "-")
+    short_effect = (move.get("short_effect") or "").lower()
+    short_effect_zh = move.get("short_effect_zh") or ""
+    always_crit_moves = {
+        "wicked-blow",
+        "surging-strikes",
+        "flower-trick",
+        "frost-breath",
+        "storm-throw",
+    }
+    if move_name in always_crit_moves:
+        return True
+    if "always results in a critical hit" in short_effect:
+        return True
+    if "必定会击中要害" in short_effect_zh:
         return True
     return False
 
@@ -533,6 +559,7 @@ def create_app():
                 "battle_mode": battle_mode,
                 "is_spread_move": is_spread,
                 "is_multi_hit": _is_multi_hit_move(move),
+                "is_guaranteed_crit": _is_guaranteed_crit_move(move),
                 "rows": rows,
             })
         except Exception as e:

--- a/pokepilot/ui/ui_server.py
+++ b/pokepilot/ui/ui_server.py
@@ -118,7 +118,8 @@ def _compute_damage_range(attacker, defender, move):
 
 def _is_spread_move(move):
     """轻量识别双打范围招式（命中多个目标时会有伤害修正）。"""
-    move_name = (move.get("name") or "").lower()
+    move_name_raw = (move.get("name") or "").lower().strip()
+    move_name = move_name_raw.replace(" ", "-").replace("_", "-")
     short_effect = (move.get("short_effect") or "").lower()
     short_effect_zh = move.get("short_effect_zh") or ""
     spread_move_names = {
@@ -164,9 +165,11 @@ def _apply_spread_modifier(range_info, battle_mode, is_spread_move):
     if battle_mode != "double" or not is_spread_move:
         return range_info
     modifier = 0.75
+    damage_min = 0 if range_info["damage_min"] <= 0 else max(1, floor(range_info["damage_min"] * modifier))
+    damage_max = 0 if range_info["damage_max"] <= 0 else max(1, floor(range_info["damage_max"] * modifier))
     return {
-        "damage_min": max(1, floor(range_info["damage_min"] * modifier)),
-        "damage_max": max(1, floor(range_info["damage_max"] * modifier)),
+        "damage_min": damage_min,
+        "damage_max": damage_max,
         "hp_pct_min": round(range_info["hp_pct_min"] * modifier, 2),
         "hp_pct_max": round(range_info["hp_pct_max"] * modifier, 2),
         "type_multiplier": range_info["type_multiplier"],

--- a/pokepilot/ui/ui_server.py
+++ b/pokepilot/ui/ui_server.py
@@ -99,14 +99,10 @@ def _compute_damage_range(attacker, defender, move):
 
     stab = 1.5 if move_type in attacker.get("types", []) else 1.0
     # 最低伤害：最低 roll + 对方最大防御
-    is_guaranteed_crit = _is_guaranteed_crit_move(move)
-    crit_modifier = 1.5 if is_guaranteed_crit else 1.0
-    damage_min = _compute_damage_with_roll(
-        power, atk_stat, def_max, stab * crit_modifier, type_multiplier, 85
-    )
+    damage_min = _compute_damage_with_roll(power, atk_stat, def_max, stab, type_multiplier, 85)
     # 最高伤害：最高 roll + 对方最小防御
     damage_max = _compute_damage_with_roll(
-        power, atk_stat, max(def_min, 1), stab * crit_modifier, type_multiplier, 100
+        power, atk_stat, max(def_min, 1), stab, type_multiplier, 100
     )
     hp_pct_min = round(damage_min * 100 / hp_max, 2)
     hp_pct_max = round(damage_max * 100 / hp_min, 2)
@@ -117,7 +113,6 @@ def _compute_damage_range(attacker, defender, move):
         "hp_pct_min": hp_pct_min,
         "hp_pct_max": hp_pct_max,
         "type_multiplier": type_multiplier,
-        "is_guaranteed_crit": is_guaranteed_crit,
     }
 
 
@@ -194,27 +189,6 @@ def _is_multi_hit_move(move):
     if any(token in short_effect for token in multi_hit_tokens):
         return True
     if "连续" in short_effect_zh and "攻击" in short_effect_zh:
-        return True
-    return False
-
-
-def _is_guaranteed_crit_move(move):
-    """识别必定击中要害技能。"""
-    move_name = (move.get("name") or "").lower().strip().replace(" ", "-").replace("_", "-")
-    short_effect = (move.get("short_effect") or "").lower()
-    short_effect_zh = move.get("short_effect_zh") or ""
-    always_crit_moves = {
-        "wicked-blow",
-        "surging-strikes",
-        "flower-trick",
-        "frost-breath",
-        "storm-throw",
-    }
-    if move_name in always_crit_moves:
-        return True
-    if "always results in a critical hit" in short_effect:
-        return True
-    if "必定会击中要害" in short_effect_zh:
         return True
     return False
 
@@ -559,7 +533,6 @@ def create_app():
                 "battle_mode": battle_mode,
                 "is_spread_move": is_spread,
                 "is_multi_hit": _is_multi_hit_move(move),
-                "is_guaranteed_crit": _is_guaranteed_crit_move(move),
                 "rows": rows,
             })
         except Exception as e:

--- a/pokepilot/ui/ui_server.py
+++ b/pokepilot/ui/ui_server.py
@@ -9,6 +9,7 @@ import argparse
 import io
 import json
 import shutil
+from math import floor
 from pathlib import Path
 from flask import Flask, send_file, request, jsonify, send_from_directory
 from flask_cors import CORS
@@ -28,6 +29,165 @@ OPP_TEAM_DIR = PROJECT_ROOT / "data" / "opp_team"
 
 # 全局 PokemonDetector 实例
 _pokemon_detector = None
+_DAMAGE_LEVEL = 50
+
+
+def _to_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _stat_min_max(value):
+    """将属性值统一为 (min, max) 区间。"""
+    if isinstance(value, list) and value:
+        values = [_to_int(v, 0) for v in value]
+        return min(values), max(values)
+    scalar = _to_int(value, 0)
+    return scalar, scalar
+
+
+def _attacker_stat_value(value):
+    """攻击方属性取最大值，兼容对方队伍的区间属性。"""
+    if isinstance(value, list) and value:
+        return max(_to_int(v, 0) for v in value)
+    return _to_int(value, 0)
+
+
+def _compute_damage_with_roll(power, atk, defense, stab, type_multiplier, roll):
+    if power <= 0 or atk <= 0 or defense <= 0 or type_multiplier <= 0:
+        return 0
+    base = floor(floor((2 * _DAMAGE_LEVEL) / 5 + 2) * power * atk / defense / 50) + 2
+    return max(1, floor(base * stab * type_multiplier * roll / 100))
+
+
+def _compute_damage_range(attacker, defender, move):
+    """计算某技能对目标的极限伤害范围（对方属性取极限值）。"""
+    power = _to_int(move.get("power"), 0)
+    if power <= 0:
+        return None
+
+    category = (move.get("category") or "").lower()
+    if category == "physical":
+        atk_stat = _attacker_stat_value(attacker.get("stats", {}).get("attack"))
+        def_min, def_max = _stat_min_max(defender.get("stats", {}).get("defense"))
+    elif category == "special":
+        atk_stat = _attacker_stat_value(attacker.get("stats", {}).get("sp_atk"))
+        def_min, def_max = _stat_min_max(defender.get("stats", {}).get("sp_def"))
+    else:
+        return None
+
+    if atk_stat <= 0 or def_max <= 0:
+        return None
+
+    hp_min, hp_max = _stat_min_max(defender.get("stats", {}).get("hp"))
+    hp_min = max(hp_min, 1)
+    hp_max = max(hp_max, 1)
+
+    move_type = move.get("type", "")
+    effectiveness = defender.get("type_effectiveness", {})
+    type_multiplier = float(effectiveness.get(move_type.lower(), 1.0))
+    if type_multiplier <= 0:
+        return {
+            "damage_min": 0,
+            "damage_max": 0,
+            "hp_pct_min": 0.0,
+            "hp_pct_max": 0.0,
+            "type_multiplier": type_multiplier,
+        }
+
+    stab = 1.5 if move_type in attacker.get("types", []) else 1.0
+    # 最低伤害：最低 roll + 对方最大防御
+    damage_min = _compute_damage_with_roll(power, atk_stat, def_max, stab, type_multiplier, 85)
+    # 最高伤害：最高 roll + 对方最小防御
+    damage_max = _compute_damage_with_roll(
+        power, atk_stat, max(def_min, 1), stab, type_multiplier, 100
+    )
+    hp_pct_min = round(damage_min * 100 / hp_max, 2)
+    hp_pct_max = round(damage_max * 100 / hp_min, 2)
+
+    return {
+        "damage_min": damage_min,
+        "damage_max": damage_max,
+        "hp_pct_min": hp_pct_min,
+        "hp_pct_max": hp_pct_max,
+        "type_multiplier": type_multiplier,
+    }
+
+
+def _is_spread_move(move):
+    """轻量识别双打范围招式（命中多个目标时会有伤害修正）。"""
+    move_name = (move.get("name") or "").lower()
+    short_effect = (move.get("short_effect") or "").lower()
+    short_effect_zh = move.get("short_effect_zh") or ""
+    spread_move_names = {
+        "heat-wave",
+        "rock-slide",
+        "blizzard",
+        "earthquake",
+        "surf",
+        "discharge",
+        "dazzling-gleam",
+        "muddy-water",
+        "snarl",
+        "icy-wind",
+        "electroweb",
+        "eruption",
+        "water-spout",
+        "hyper-voice",
+        "boomburst",
+        "sludge-wave",
+        "brutal-swing",
+        "lava-plume",
+        "bulldoze",
+        "breaking-swipe",
+    }
+    if move_name in spread_move_names:
+        return True
+    spread_tokens_en = [
+        "all adjacent foes",
+        "all adjacent pokemon",
+        "hits both opponents",
+        "all other pokemon",
+    ]
+    spread_tokens_zh = ["全体", "所有", "双方", "除自己以外"]
+    if any(token in short_effect for token in spread_tokens_en):
+        return True
+    if any(token in short_effect_zh for token in spread_tokens_zh):
+        return True
+    return False
+
+
+def _apply_spread_modifier(range_info, battle_mode, is_spread_move):
+    """双打下范围技能伤害修正。"""
+    if battle_mode != "double" or not is_spread_move:
+        return range_info
+    modifier = 0.75
+    return {
+        "damage_min": max(1, floor(range_info["damage_min"] * modifier)),
+        "damage_max": max(1, floor(range_info["damage_max"] * modifier)),
+        "hp_pct_min": round(range_info["hp_pct_min"] * modifier, 2),
+        "hp_pct_max": round(range_info["hp_pct_max"] * modifier, 2),
+        "type_multiplier": range_info["type_multiplier"],
+    }
+
+
+def _is_multi_hit_move(move):
+    """基于技能描述做轻量识别：是否可能为多段伤害技能。"""
+    short_effect = (move.get("short_effect") or "").lower()
+    short_effect_zh = move.get("short_effect_zh") or ""
+    multi_hit_tokens = [
+        "2 to 5 times",
+        "hits 2 times",
+        "hits twice",
+        "two to five times",
+    ]
+    if any(token in short_effect for token in multi_hit_tokens):
+        return True
+    if "连续" in short_effect_zh and "攻击" in short_effect_zh:
+        return True
+    return False
 
 def get_detector():
     """获取全局 PokemonDetector 实例（懒加载）"""
@@ -311,6 +471,66 @@ def create_app():
                 "success": True,
                 "team": team_data,
                 "slot": "temp"
+            })
+        except Exception as e:
+            return jsonify({"success": False, "error": str(e)}), 500
+
+    @app.route("/api/damage/range", methods=["GET", "POST"])
+    def damage_range():
+        """点击我方技能后，返回该技能对对方全队的伤害范围。"""
+        try:
+            body = request.get_json(silent=True) or {}
+            if request.method == "GET" and not body:
+                payload = request.args.get("payload", "")
+                body = json.loads(payload) if payload else {}
+            attacker = body.get("attacker") or {}
+            move_index = _to_int(body.get("move_index"), -1)
+            opp_team = body.get("opp_team") or []
+            battle_mode = body.get("battle_mode") or "double"
+            if battle_mode not in ("single", "double"):
+                battle_mode = "double"
+
+            moves = attacker.get("moves") or []
+            if move_index < 0 or move_index >= len(moves):
+                return jsonify({"success": False, "error": "无效的技能索引"}), 400
+
+            move = moves[move_index]
+            if not move or move.get("power") is None:
+                return jsonify({"success": False, "error": "该技能非伤害技能"}), 400
+            is_spread = _is_spread_move(move)
+
+            rows = []
+            for opp in opp_team:
+                range_info = _compute_damage_range(attacker, opp, move)
+                if range_info is None:
+                    continue
+                range_info = _apply_spread_modifier(range_info, battle_mode, is_spread)
+                hp_min, hp_max = _stat_min_max((opp.get("stats") or {}).get("hp"))
+                rows.append({
+                    "opp_name": opp.get("name", ""),
+                    "opp_name_zh": opp.get("name_zh", ""),
+                    "opp_types": opp.get("types", []),
+                    "opp_hp_min": hp_min,
+                    "opp_hp_max": hp_max,
+                    "range": range_info,
+                })
+
+            rows.sort(
+                key=lambda item: (
+                    item["range"]["hp_pct_max"],
+                    item["range"]["hp_pct_min"],
+                ),
+                reverse=True,
+            )
+            return jsonify({
+                "success": True,
+                "move_name": move.get("name", ""),
+                "move_name_zh": move.get("name_zh", ""),
+                "move_priority": _to_int(move.get("priority"), 0),
+                "battle_mode": battle_mode,
+                "is_spread_move": is_spread,
+                "is_multi_hit": _is_multi_hit_move(move),
+                "rows": rows,
             })
         except Exception as e:
             return jsonify({"success": False, "error": str(e)}), 500


### PR DESCRIPTION
## 描述
本 PR 为 Web UI 增加了技能伤害范围查看能力，支持在我方/对方队伍生成后，通过点击技能直接查看对位伤害区间。  
同时增加了单双打模式切换、双打范围技能修正、先制度展示及多段技能提示，提升了对战中伤害判断效率。

## 问题类型
- [ ] Bug修复
- [x] 新功能
- [ ] 文档更新

## 测试方式
1. 启动服务：`python -m pokepilot.ui.ui_server --port 8765`
2. 在 UI 中生成我方队伍与对方队伍
3. 点击我方任意技能，验证悬浮窗显示该技能对对方全队的：
   - 伤害范围（min-max）
   - 生命值百分比范围
   - 对方极限 HP 区间
   - 对方属性图标
4. 点击对方常用技能，验证可反向显示对我方全队伤害范围
5. 拖拽悬浮窗标题栏，验证可移动
6. 切换“单打/双打”按钮，验证双打下范围技能应用 0.75 修正
7. 验证技能处显示先制度（如 `P+1`），悬浮窗标题可显示先制度
8. 对多段技能验证标题提示“多段技能，当前为单段伤害”

## 截图
<img width="1512" height="982" alt="截屏2026-04-27 15 07 07" src="https://github.com/user-attachments/assets/935c060e-1399-428f-9c4f-21f633d57e58" />
<img width="1512" height="982" alt="截屏2026-04-27 15 07 09" src="https://github.com/user-attachments/assets/7eb3c22f-2f78-4df6-beb1-105bee9de3d1" />
<img width="1512" height="982" alt="截屏2026-04-27 15 07 11" src="https://github.com/user-attachments/assets/3b5fc4b4-a7bd-4edc-9e0c-3f9e00ada34d" />

## 检查清单
- [x] 代码遵循项目风格
- [x] 已自测功能
- [ ] 更新了文档